### PR TITLE
Fix serious GCC and flash memory bug

### DIFF
--- a/core/flash.c
+++ b/core/flash.c
@@ -1,14 +1,18 @@
 #include "flash.h"
 #include "stm32f4xx_hal.h"
 
-#define SECTOR_3_ADD_START 
-#define SECTOR_3_ADD_FIN   0x0800FFFF
 #define SECTOR_3_SIZE	   0x1000
 
 #define TRANSMIT_VAR_ADD   0x0800C000
 
-#pragma location = 0x0800C000 
-const uint32_t occupy_sector[SECTOR_3_SIZE] = { 0xa94249da, 0x0A };
+#ifdef __GNUC__
+const uint32_t __attribute__((section (".comms_storage_section"))) occupy_sector[SECTOR_3_SIZE] __attribute__ ((aligned (4)))
+    =
+      { 0x16264e84, 0x0A };
+#else
+#pragma location = 0x0800C000
+const uint32_t occupy_sector[SECTOR_3_SIZE] = { 0x16264e84, 0x0A };
+#endif
 
 uint32_t flash_INIT() {
     return occupy_sector[0];

--- a/platform/comms/comms.c
+++ b/platform/comms/comms.c
@@ -78,7 +78,7 @@ route_pkt (tc_tm_pkt *pkt)
                pkt->ser_type == TC_HOUSEKEEPING_SERVICE &&
                pkt->ser_subtype == TM_HK_PARAMETERS_REPORT &&
                pkt->data[0] == WOD_REP) {
-
+    tx_ecss(pkt);
   }
   else if (id == SYSTEM_APP_ID && pkt->ser_type == TC_HOUSEKEEPING_SERVICE) {
     //C_ASSERT(pkt->ser_subtype == 21 || pkt->ser_subtype == 23) { free_pkt(pkt); return SATR_ERROR; }


### PR DESCRIPTION
GCC does not support the #pragma location macro. So the flash memory
storage block could actually write/erase on the .text or .data segment
of the program
