### PR TITLE
WIP: ver service

### DIFF
--- a/platform/obc/housekeeping.c
+++ b/platform/obc/housekeeping.c
@@ -83,8 +83,8 @@ void hk_SCH() {
     wdg_reset_HK();
     HAL_sys_delay(12500);  
 
-    //hk_crt_pkt_TM(&hk_pkt, COMMS_APP_ID, EXT_WOD_REP);
-    hk_crt_pkt_TM(&hk_pkt, DBG_APP_ID, EXT_WOD_REP);
+    hk_crt_pkt_TM(&hk_pkt, COMMS_APP_ID, EXT_WOD_REP);
+    //hk_crt_pkt_TM(&hk_pkt, DBG_APP_ID, EXT_WOD_REP);
     route_pkt(&hk_pkt);
     wake_uart_task();
     clear_ext_wod();

--- a/services/verification_service.c
+++ b/services/verification_service.c
@@ -25,9 +25,11 @@ SAT_returnState verification_app(const tc_tm_pkt *pkt) {
     }
     else {
 
-        if(!C_ASSERT(pkt->ack == TC_ACK_ACC || pkt->ack == TC_ACK_NO) == true) { return SATR_ERROR; }
+        if(!C_ASSERT(pkt->ack == TC_ACK_ACC ||
+                     pkt->ack == TC_ACK_NO) == true) { return SATR_ERROR; }
         if(pkt->type == TM) { return SATR_OK; }
         if(pkt->app_id != SYSTEM_APP_ID ||
+           pkt->verification_state != SATR_OK ||
            pkt->verification_state != SATR_OK) { return SATR_OK; }
         
         if(pkt->ack == TC_ACK_NO) { return SATR_OK; }

--- a/services/verification_service.c
+++ b/services/verification_service.c
@@ -28,9 +28,9 @@ SAT_returnState verification_app(const tc_tm_pkt *pkt) {
         if(!C_ASSERT(pkt->ack == TC_ACK_ACC ||
                      pkt->ack == TC_ACK_NO) == true) { return SATR_ERROR; }
         if(pkt->type == TM) { return SATR_OK; }
-        if(pkt->app_id != SYSTEM_APP_ID ||
-           pkt->verification_state != SATR_OK ||
-           pkt->verification_state != SATR_OK) { return SATR_OK; }
+        if(pkt->app_id != SYSTEM_APP_ID &&
+           (pkt->verification_state == SATR_OK ||
+           pkt->verification_state == SATR_PKT_INIT)) { return SATR_OK; }
         
         if(pkt->ack == TC_ACK_NO) { return SATR_OK; }
         else if(pkt->ack == TC_ACK_ACC) {

--- a/services/verification_service.c
+++ b/services/verification_service.c
@@ -27,7 +27,8 @@ SAT_returnState verification_app(const tc_tm_pkt *pkt) {
 
         if(!C_ASSERT(pkt->ack == TC_ACK_ACC || pkt->ack == TC_ACK_NO) == true) { return SATR_ERROR; }
         if(pkt->type == TM) { return SATR_OK; }
-        if(pkt->app_id != SYSTEM_APP_ID) { return SATR_OK; }
+        if(pkt->app_id != SYSTEM_APP_ID ||
+           pkt->verification_state != SATR_OK) { return SATR_OK; }
         
         if(pkt->ack == TC_ACK_NO) { return SATR_OK; }
         else if(pkt->ack == TC_ACK_ACC) {


### PR DESCRIPTION
Added verification service when a packet is not destined for the subsystem but has error. This is for comms when a packet is firewalled and for obc when there is an error in route.

<!---
@huboard:{"custom_state":"archived"}
-->
